### PR TITLE
Correctly use ES6 promises in KeyEncryptor

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -85,5 +85,7 @@
   "yui"           : false,    // Yahoo User Interface
 
   // Custom Globals
-  "globals"       : {}        // additional predefined global variables
+  "globals"       : {         // Additional predefined global variables
+    "Promise": false
+  }
 }

--- a/lib/crypto/key-encryptor.js
+++ b/lib/crypto/key-encryptor.js
@@ -9,11 +9,14 @@ var credentialSize = 32;
 var maxBufferSize = aesBlockSize * maxRoundsPreIteration;
 
 function encrypt(credentials, key, rounds, callback) {
-    var result;
+    var result = Promise.resolve();
     if (!subtle) {
         result = Promise.reject("No subtle crypto");
     } else {
-        result = subtle.importKey('raw', key, {name: 'AES-CBC'}, false, ['encrypt'])
+        result = result
+            .then(function() {
+                return subtle.importKey('raw', key, {name: 'AES-CBC'}, false, ['encrypt']);
+            })
             .then(function(encKey) {
                 var resolvers = [];
                 for (var idx=0; idx<credentialSize; idx += aesBlockSize) {
@@ -59,7 +62,7 @@ function encryptBlock(iv, encKey, rounds, buffer) {
             buffer = new Uint8Array(dataLen);
         }
         var zeroData = buffer.length === dataLen ? buffer : buffer.subarray(0, dataLen);
-        result
+        result = result
             .then(function (iv) {
                 return subtle.encrypt({name: 'AES-CBC', iv: iv}, encKey, zeroData);
             }).then(function (data) {

--- a/lib/crypto/key-encryptor.js
+++ b/lib/crypto/key-encryptor.js
@@ -21,14 +21,14 @@ function encrypt(credentials, key, rounds, callback) {
                 var resolvers = [];
                 for (var idx=0; idx<credentialSize; idx += aesBlockSize) {
                     resolvers.push(encryptBlock(
-                        credentials.subarray(idx, aesBlockSize), encKey, rounds));
+                        credentials.subarray(idx, idx+aesBlockSize), encKey, rounds));
                 }
                 return Promise.all(resolvers)
             })
             .then(function(results) {
                 var concat = new Uint8Array(credentialSize);
 
-                results.forEach(function(result, idx) {
+                results.forEach(function (result, idx) {
                     var base = idx * aesBlockSize;
                     for (var i=0; i<aesBlockSize; ++i) {
                         concat[i + base] = result[i];
@@ -43,33 +43,34 @@ function encrypt(credentials, key, rounds, callback) {
     }
 }
 
-function encryptBlock(iv, encKey, rounds, buffer) {
+function encryptBlock(iv, encKey, rounds) {
     if (!subtle) {
         return Promise.reject("No subtle crypto");
     }
 
-    var actualRounds = rounds;
-    var roundCap = buffer && buffer.length >= aesBlockSize ?
-        Math.floor(buffer.length / aesBlockSize) : maxRoundsPreIteration;
-
     var result = Promise.resolve(iv);
+    var buffer = new Uint8Array(aesBlockSize * Math.min(rounds, maxRoundsPreIteration));
 
-    for (var roundsLeft = rounds; roundsLeft > 0; roundsLeft -= roundCap) {
-        var actualRounds = Math.max(roundsLeft, roundsCap);
-        var dataLen = actualRounds * aesBlockSize;
-        if (!buffer) {
-            buffer = new Uint8Array(dataLen);
-        }
+    while (rounds > 0) {
+        var currentRounds = Math.min(rounds, maxRoundsPreIteration);
+        rounds -= currentRounds;
+
+        var dataLen = aesBlockSize * currentRounds;
         var zeroData = buffer.length === dataLen ? buffer : buffer.subarray(0, dataLen);
-        result = result
-            .then(function (iv) {
-                return subtle.encrypt({name: 'AES-CBC', iv: iv}, encKey, zeroData);
-            }).then(function (data) {
-                return new Uint8Array(data, (actualRounds - 1) * aesBlockSize, aesBlockSize);
-            });
+        result = encryptBlockBuffer(result, encKey, zeroData);
     }
 
     return result;
+}
+
+function encryptBlockBuffer(promisedIv, encKey, buffer) {
+    return promisedIv
+        .then(function(iv) {
+            return subtle.encrypt({name: 'AES-CBC', iv: iv}, encKey, buffer);
+        })
+        .then(function(data) {
+            return new Uint8Array(data, data.byteLength - 2*aesBlockSize, aesBlockSize);
+        })
 }
 
 function fallbackEncrypt(credentials, key, rounds, callback) {

--- a/lib/crypto/key-encryptor.js
+++ b/lib/crypto/key-encryptor.js
@@ -6,12 +6,10 @@ var subtle = global.crypto ? global.crypto.subtle || global.crypto.webkitSubtle 
 var maxRoundsPreIteration = 10000;
 var aesBlockSize = 16;
 var credentialSize = 32;
-var maxBufferSize = aesBlockSize * maxRoundsPreIteration;
 
 function encrypt(credentials, key, rounds, callback) {
     if (!subtle) {
         fallbackEncrypt(credentials, key, rounds, callback);
-        return;
     } else {
         Promise.resolve()
             .then(function() {
@@ -19,25 +17,25 @@ function encrypt(credentials, key, rounds, callback) {
             })
             .then(function(encKey) {
                 var resolvers = [];
-                for (var idx=0; idx<credentialSize; idx += aesBlockSize) {
+                for (var idx = 0; idx < credentialSize; idx += aesBlockSize) {
                     resolvers.push(encryptBlock(
-                        credentials.subarray(idx, idx+aesBlockSize), encKey, rounds));
+                        credentials.subarray(idx, idx + aesBlockSize), encKey, rounds));
                 }
-                return Promise.all(resolvers)
+                return Promise.all(resolvers);
             })
             .then(function(results) {
                 var concat = new Uint8Array(credentialSize);
 
                 results.forEach(function (result, idx) {
                     var base = idx * aesBlockSize;
-                    for (var i=0; i<aesBlockSize; ++i) {
+                    for (var i = 0; i < aesBlockSize; ++i) {
                         concat[i + base] = result[i];
                     }
                 });
 
                 return concat;
             })
-            .then(callback, function(err) {
+            .then(callback, function() {
                 fallbackEncrypt(credentials, key, rounds, callback);
             });
     }
@@ -64,9 +62,9 @@ function encryptBlockBuffer(promisedIv, encKey, buffer) {
         .then(function(iv) {
             return subtle.encrypt({name: 'AES-CBC', iv: iv}, encKey, buffer);
         })
-        .then(function(data) {
-            return new Uint8Array(data, data.byteLength - 2*aesBlockSize, aesBlockSize);
-        })
+        .then(function(buf) {
+            return new Uint8Array(buf).slice(-2 * aesBlockSize, -aesBlockSize);
+        });
 }
 
 function fallbackEncrypt(credentials, key, rounds, callback) {

--- a/lib/crypto/key-encryptor.js
+++ b/lib/crypto/key-encryptor.js
@@ -9,11 +9,11 @@ var credentialSize = 32;
 var maxBufferSize = aesBlockSize * maxRoundsPreIteration;
 
 function encrypt(credentials, key, rounds, callback) {
-    var result = Promise.resolve();
     if (!subtle) {
-        result = Promise.reject("No subtle crypto");
+        fallbackEncrypt(credentials, key, rounds, callback);
+        return;
     } else {
-        result = result
+        Promise.resolve()
             .then(function() {
                 return subtle.importKey('raw', key, {name: 'AES-CBC'}, false, ['encrypt']);
             })
@@ -36,12 +36,11 @@ function encrypt(credentials, key, rounds, callback) {
                 });
 
                 return concat;
+            })
+            .then(callback, function(err) {
+                fallbackEncrypt(credentials, key, rounds, callback);
             });
     }
-
-    result.then(callback, function(err) {
-        fallbackEncrypt(credentials, key, rounds, callback);
-    });
 }
 
 function encryptBlock(iv, encKey, rounds, buffer) {
@@ -74,7 +73,7 @@ function encryptBlock(iv, encKey, rounds, buffer) {
 }
 
 function fallbackEncrypt(credentials, key, rounds, callback) {
-    return Promise.resolve(asmCrypto.AES_ECB.encrypt(credentials, key, false, rounds));
+    callback(asmCrypto.AES_ECB.encrypt(credentials, key, false, rounds));
 }
 
 module.exports.encrypt = encrypt;

--- a/lib/crypto/key-encryptor.js
+++ b/lib/crypto/key-encryptor.js
@@ -44,10 +44,6 @@ function encrypt(credentials, key, rounds, callback) {
 }
 
 function encryptBlock(iv, encKey, rounds) {
-    if (!subtle) {
-        return Promise.reject("No subtle crypto");
-    }
-
     var result = Promise.resolve(iv);
     var buffer = new Uint8Array(aesBlockSize * Math.min(rounds, maxRoundsPreIteration));
 

--- a/lib/crypto/key-encryptor.js
+++ b/lib/crypto/key-encryptor.js
@@ -2,70 +2,76 @@
 
 var asmCrypto = require('asmcrypto.js');
 var subtle = global.crypto ? global.crypto.subtle || global.crypto.webkitSubtle : null;
-var MaxRoundsPreIteration = 10000;
 
-function encrypt(data, key, rounds, callback) {
+var maxRoundsPreIteration = 10000;
+var aesBlockSize = 16;
+var credentialSize = 32;
+var maxBufferSize = aesBlockSize * maxRoundsPreIteration;
+
+function encrypt(credentials, key, rounds, callback) {
+    var result;
     if (!subtle) {
-        fallbackEncrypt(data, key, rounds, callback);
+        result = Promise.reject("No subtle crypto");
     } else {
-        try {
-            subtle.importKey('raw', key, {name: 'AES-CBC'}, false, ['encrypt']).then(function (encKey) {
-                var result = new Uint8Array(32);
-                var partsLeft = 2;
-                encryptBlock(data.subarray(0, 16), encKey, rounds, result, function (enc) {
-                    if (!enc) {
-                        return --partsLeft ? null : fallbackEncrypt(data, key, rounds, callback);
-                    }
-                    for (var i = 0; i < 16; i++) {
-                        result[i] = enc[i];
-                    }
-                    if (!--partsLeft) {
-                        callback(result);
-                    }
-                });
-                encryptBlock(data.subarray(16), encKey, rounds, result, function (enc) {
-                    if (!enc) {
-                        return --partsLeft ? null : fallbackEncrypt(data, key, rounds, callback);
-                    }
-                    for (var i = 0; i < 16; i++) {
-                        result[i + 16] = enc[i];
-                    }
-                    if (!--partsLeft) {
-                        callback(result);
+        result = subtle.importKey('raw', key, {name: 'AES-CBC'}, false, ['encrypt'])
+            .then(function(encKey) {
+                var resolvers = [];
+                for (var idx=0; idx<credentialSize; idx += aesBlockSize) {
+                    resolvers.push(encryptBlock(
+                        credentials.subarray(idx, aesBlockSize), encKey, rounds));
+                }
+                return Promise.all(resolvers)
+            })
+            .then(function(results) {
+                var concat = new Uint8Array(credentialSize);
+
+                results.forEach(function(result, idx) {
+                    var base = idx * aesBlockSize;
+                    for (var i=0; i<aesBlockSize; ++i) {
+                        concat[i + base] = result[i];
                     }
                 });
-            }).catch(function () {
-                fallbackEncrypt(data, key, rounds, callback);
+
+                return concat;
             });
-        } catch (e) {
-            fallbackEncrypt(data, key, rounds, callback);
+    }
+
+    result.then(callback, function(err) {
+        fallbackEncrypt(credentials, key, rounds, callback);
+    });
+}
+
+function encryptBlock(iv, encKey, rounds, buffer) {
+    if (!subtle) {
+        return Promise.reject("No subtle crypto");
+    }
+
+    var actualRounds = rounds;
+    var roundCap = buffer && buffer.length >= aesBlockSize ?
+        Math.floor(buffer.length / aesBlockSize) : maxRoundsPreIteration;
+
+    var result = Promise.resolve(iv);
+
+    for (var roundsLeft = rounds; roundsLeft > 0; roundsLeft -= roundCap) {
+        var actualRounds = Math.max(roundsLeft, roundsCap);
+        var dataLen = actualRounds * aesBlockSize;
+        if (!buffer) {
+            buffer = new Uint8Array(dataLen);
         }
+        var zeroData = buffer.length === dataLen ? buffer : buffer.subarray(0, dataLen);
+        result
+            .then(function (iv) {
+                return subtle.encrypt({name: 'AES-CBC', iv: iv}, encKey, zeroData);
+            }).then(function (data) {
+                return new Uint8Array(data, (actualRounds - 1) * aesBlockSize, aesBlockSize);
+            });
     }
+
+    return result;
 }
 
-function encryptBlock(iv, encKey, rounds, result, complete, buffer) {
-    var actualRounds = Math.min(MaxRoundsPreIteration, rounds);
-    var leftRounds = rounds - actualRounds;
-    var dataLen = 16 * actualRounds;
-    var zeroData = buffer ? buffer.length === dataLen ? buffer : buffer.subarray(0, dataLen) : new Uint8Array(dataLen);
-    try {
-        subtle.encrypt({name: 'AES-CBC', iv: iv}, encKey, zeroData).then(function (encData) {
-            var encDataArr = new Uint8Array(encData, (actualRounds - 1) * 16, 16);
-            if (leftRounds) {
-                encryptBlock(encDataArr, encKey, leftRounds, result, complete, buffer || zeroData);
-            } else {
-                complete(encDataArr);
-            }
-        }).catch(function () {
-            complete();
-        });
-    } catch (e) {
-        complete();
-    }
-}
-
-function fallbackEncrypt(data, key, rounds, callback) {
-    callback(asmCrypto.AES_ECB.encrypt(data, key, false, rounds));
+function fallbackEncrypt(credentials, key, rounds, callback) {
+    return Promise.resolve(asmCrypto.AES_ECB.encrypt(credentials, key, false, rounds));
 }
 
 module.exports.encrypt = encrypt;


### PR DESCRIPTION
Instead of using complicated try-catch and multiple catch clauses, KeyEncryptor can be refactored to use ES6 promise syntax that is much more concise and readable.

All tests pass with this change, although a few tests were refactored to get them to work properly if subtle crypto is not available.