### PR TITLE
Zero intermediate results in key encryptor

### DIFF
--- a/lib/crypto/key-encryptor.js
+++ b/lib/crypto/key-encryptor.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var asmCrypto = require('asmcrypto.js');
+var ByteUtils = require('./../utils/byte-utils'),
+    asmCrypto = require('asmcrypto.js');
 var subtle = global.crypto ? global.crypto.subtle || global.crypto.webkitSubtle : null;
 
 var maxRoundsPreIteration = 10000;
@@ -31,6 +32,7 @@ function encrypt(credentials, key, rounds, callback) {
                     for (var i = 0; i < aesBlockSize; ++i) {
                         concat[i + base] = result[i];
                     }
+                    ByteUtils.zeroBuffer(result);
                 });
 
                 return concat;
@@ -63,7 +65,10 @@ function encryptBlockBuffer(promisedIv, encKey, buffer) {
             return subtle.encrypt({name: 'AES-CBC', iv: iv}, encKey, buffer);
         })
         .then(function(buf) {
-            return new Uint8Array(buf).slice(-2 * aesBlockSize, -aesBlockSize);
+            var data = new Uint8Array(buf);
+            var nextIv = data.slice(-2 * aesBlockSize, -aesBlockSize);
+            ByteUtils.zeroBuffer(data);
+            return nextIv;
         });
 }
 


### PR DESCRIPTION
Intermediate results contain the partially encrypted hash of the
master key, which could be used to recover the master key from memory.