### PR TITLE
Key encryptor promise interface

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -85,7 +85,5 @@
   "yui"           : false,    // Yahoo User Interface
 
   // Custom Globals
-  "globals"       : {         // Additional predefined global variables
-    "Promise": false
-  }
+  "globals"       : {}        // Additional predefined global variables
 }

--- a/lib/crypto/key-encryptor.js
+++ b/lib/crypto/key-encryptor.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var ByteUtils = require('./../utils/byte-utils'),
+var Promise = require('bluebird'),
+    ByteUtils = require('./../utils/byte-utils'),
     asmCrypto = require('asmcrypto.js');
 var subtle = global.crypto ? global.crypto.subtle || global.crypto.webkitSubtle : null;
 
@@ -9,10 +10,11 @@ var aesBlockSize = 16;
 var credentialSize = 32;
 
 function encrypt(credentials, key, rounds, callback) {
+    var result;
     if (!subtle) {
-        fallbackEncrypt(credentials, key, rounds, callback);
+        result = Promise.reject('No subtle crypto');
     } else {
-        Promise.resolve()
+        result = Promise.resolve()
             .then(function() {
                 return subtle.importKey('raw', key, {name: 'AES-CBC'}, false, ['encrypt']);
             })
@@ -36,11 +38,14 @@ function encrypt(credentials, key, rounds, callback) {
                 });
 
                 return concat;
-            })
-            .then(callback, function() {
-                fallbackEncrypt(credentials, key, rounds, callback);
             });
     }
+
+    result
+        .catch(function() {
+            return fallbackEncrypt(credentials, key, rounds);
+        })
+        .then(callback);
 }
 
 function encryptBlock(iv, encKey, rounds) {
@@ -72,8 +77,8 @@ function encryptBlockBuffer(promisedIv, encKey, buffer) {
         });
 }
 
-function fallbackEncrypt(credentials, key, rounds, callback) {
-    callback(asmCrypto.AES_ECB.encrypt(credentials, key, false, rounds));
+function fallbackEncrypt(credentials, key, rounds) {
+    return Promise.resolve(asmCrypto.AES_ECB.encrypt(credentials, key, false, rounds));
 }
 
 module.exports.encrypt = encrypt;

--- a/lib/crypto/key-encryptor.js
+++ b/lib/crypto/key-encryptor.js
@@ -9,7 +9,7 @@ var maxRoundsPreIteration = 10000;
 var aesBlockSize = 16;
 var credentialSize = 32;
 
-function encrypt(credentials, key, rounds, callback) {
+function encrypt(credentials, key, rounds) {
     var result;
     if (!subtle) {
         result = Promise.reject('No subtle crypto');
@@ -41,11 +41,10 @@ function encrypt(credentials, key, rounds, callback) {
             });
     }
 
-    result
+    return result
         .catch(function() {
             return fallbackEncrypt(credentials, key, rounds);
-        })
-        .then(callback);
+        });
 }
 
 function encryptBlock(iv, encKey, rounds) {

--- a/lib/format/kdbx.js
+++ b/lib/format/kdbx.js
@@ -451,7 +451,7 @@ Kdbx.prototype._getMasterKey = function(callback) {
         transformSeed = this.header.transformSeed,
         transformRounds = this.header.keyEncryptionRounds,
         masterSeed = this.header.masterSeed;
-    KeyEncryptor.encrypt(credHash, transformSeed, transformRounds, function(encKey) {
+    KeyEncryptor.encrypt(credHash, transformSeed, transformRounds).then(function(encKey) {
         ByteUtils.zeroBuffer(credHash);
         var keyHash = asmCrypto.SHA256.bytes(encKey);
         ByteUtils.zeroBuffer(encKey);

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "arraybuffer-slice": "^0.1.2",
     "asmcrypto.js": "antelle/asmcrypto.js#v0.0.10-alpha-fix-4",
+    "bluebird": "^3.3.4",
     "pako": "^0.2.7",
     "xmldom": "^0.1.19"
   }

--- a/test/crypto/key-encryptor.spec.js
+++ b/test/crypto/key-encryptor.spec.js
@@ -23,7 +23,7 @@ describe('KeyEncryptor', function() {
     });
 
     it('decrypts one round with default algorithm', function(done) {
-        KeyEncryptor.encrypt(data, key, 1, function(res) {
+        KeyEncryptor.encrypt(data, key, 1).then(function(res) {
             expect(asmCrypto.bytes_to_hex(res)).to.be('46e891c182a31d005a8990ac5d61bb2124ffe5927fa008a739a9b0d217c79717');
             done();
         });
@@ -33,7 +33,7 @@ describe('KeyEncryptor', function() {
         it('uses fallback encryption if webcrypto.importKey generates promise error', function (done) {
             var oldImportKey = subtle.importKey;
             subtle.importKey = function () { return new Promise(function (resolve, reject) { reject('fail'); }); };
-            KeyEncryptor.encrypt(data, key, 1, function (res) {
+            KeyEncryptor.encrypt(data, key, 1).then(function (res) {
                 subtle.importKey = oldImportKey;
                 expect(asmCrypto.bytes_to_hex(res)).to.be('46e891c182a31d005a8990ac5d61bb2124ffe5927fa008a739a9b0d217c79717');
                 done();
@@ -43,7 +43,7 @@ describe('KeyEncryptor', function() {
         it('uses fallback encryption if webcrypto.encrypt generates promise error', function (done) {
             var oldEncrypt = subtle.encrypt;
             subtle.encrypt = function () { return new Promise(function (resolve, reject) { reject('fail'); }); };
-            KeyEncryptor.encrypt(data, key, 1, function (res) {
+            KeyEncryptor.encrypt(data, key, 1).then(function (res) {
                 subtle.encrypt = oldEncrypt;
                 expect(asmCrypto.bytes_to_hex(res)).to.be('46e891c182a31d005a8990ac5d61bb2124ffe5927fa008a739a9b0d217c79717');
                 done();
@@ -53,7 +53,7 @@ describe('KeyEncryptor', function() {
         it('uses fallback encryption if webcrypto.importKey throws an error', function (done) {
             var oldImportKey = subtle.importKey;
             subtle.importKey = function () { throw 'err'; };
-            KeyEncryptor.encrypt(data, key, 1, function (res) {
+            KeyEncryptor.encrypt(data, key, 1).then(function (res) {
                 subtle.importKey = oldImportKey;
                 expect(asmCrypto.bytes_to_hex(res)).to.be('46e891c182a31d005a8990ac5d61bb2124ffe5927fa008a739a9b0d217c79717');
                 done();
@@ -63,7 +63,7 @@ describe('KeyEncryptor', function() {
         it('uses fallback encryption if webcrypto.encrypt throws an error', function (done) {
             var oldImportKey = subtle.encrypt;
             subtle.encrypt = function () { throw 'err'; };
-            KeyEncryptor.encrypt(data, key, 1, function (res) {
+            KeyEncryptor.encrypt(data, key, 1).then(function (res) {
                 subtle.encrypt = oldImportKey;
                 expect(asmCrypto.bytes_to_hex(res)).to.be('46e891c182a31d005a8990ac5d61bb2124ffe5927fa008a739a9b0d217c79717');
                 done();
@@ -79,7 +79,7 @@ describe('KeyEncryptor', function() {
     });
 
     it('decrypts two rounds with default algorithm', function(done) {
-        KeyEncryptor.encrypt(data, key, 2, function(res) {
+        KeyEncryptor.encrypt(data, key, 2).then(function(res) {
             expect(asmCrypto.bytes_to_hex(res)).to.be('1818f732cb1a933911ec90baed252d388980cd3665e1009705e5007aa48ad916');
             done();
         });
@@ -93,7 +93,7 @@ describe('KeyEncryptor', function() {
     });
 
     it('decrypts many rounds with default algorithm', function(done) {
-        KeyEncryptor.encrypt(data, key, 10021, function(res) {
+        KeyEncryptor.encrypt(data, key, 10021).then(function(res) {
             expect(asmCrypto.bytes_to_hex(res)).to.be('64d62f7ec4a363ff0fbb4520163b478ef4d0d631b690a2e7daa6bc09bca092df');
             done();
         });

--- a/test/crypto/key-encryptor.spec.js
+++ b/test/crypto/key-encryptor.spec.js
@@ -16,7 +16,7 @@ describe('KeyEncryptor', function() {
     var key = asmCrypto.hex_to_bytes('ee66af917de0b0336e659fe6bd40a337d04e3c2b3635210fa16f28fb24d563ac');
 
     it('decrypts one round with fallback algorithm', function(done) {
-        KeyEncryptor.fallbackEncrypt(data, key, 1, function(res) {
+        KeyEncryptor.fallbackEncrypt(data, key, 1).then(function(res) {
             expect(asmCrypto.bytes_to_hex(res)).to.be('46e891c182a31d005a8990ac5d61bb2124ffe5927fa008a739a9b0d217c79717');
             done();
         });
@@ -72,7 +72,7 @@ describe('KeyEncryptor', function() {
     }
 
     it('decrypts two rounds with fallback algorithm', function(done) {
-        KeyEncryptor.fallbackEncrypt(data, key, 2, function(res) {
+        KeyEncryptor.fallbackEncrypt(data, key, 2).then(function(res) {
             expect(asmCrypto.bytes_to_hex(res)).to.be('1818f732cb1a933911ec90baed252d388980cd3665e1009705e5007aa48ad916');
             done();
         });
@@ -86,7 +86,7 @@ describe('KeyEncryptor', function() {
     });
 
     it('decrypts many rounds with fallback algorithm', function(done) {
-        KeyEncryptor.fallbackEncrypt(data, key, 10021, function(res) {
+        KeyEncryptor.fallbackEncrypt(data, key, 10021).then(function(res) {
             expect(asmCrypto.bytes_to_hex(res)).to.be('64d62f7ec4a363ff0fbb4520163b478ef4d0d631b690a2e7daa6bc09bca092df');
             done();
         });


### PR DESCRIPTION
Using promises instead of callbacks throughout KeyEncryptor maintains code style more effectively. It centralizes error-handling logic so that the program flow is easier to understand. Also, it has hardly any impact on other parts of the application, because callbacks can be translate to promises with a 5 character change.

I understand this change could be construed as opinionated, so I'm not 100% confident in it being merged.