### PR TITLE
Add explanation of ECB simulation with CBC

### DIFF
--- a/lib/crypto/key-encryptor.js
+++ b/lib/crypto/key-encryptor.js
@@ -8,6 +8,14 @@ var maxRoundsPreIteration = 10000;
 var aesBlockSize = 16;
 var credentialSize = 32;
 
+/*
+In order to simulate multiple rounds of ECB encryption, we do CBC encryption
+across a zero buffer of large length with the IV being the desired plaintext.
+The zero buffer does not contribute to the xor, so xoring the previous block
+with the next one simulates running ECB multiple times. We limit the maximum
+size of the zero buffer to prevent enormous memory usage.
+*/
+
 function encrypt(credentials, key, rounds, callback) {
     if (!subtle) {
         fallbackEncrypt(credentials, key, rounds, callback);


### PR DESCRIPTION
Future readers could be confused about why CBC is being used with very few rounds, when kdbx requires ECB with many rounds. This comment clarifies that point.